### PR TITLE
✨ [FEATURE] 주문 시 수령 방법에 따른 응답 구조 변경

### DIFF
--- a/src/main/java/umc/unimade/domain/accounts/controller/BuyerController.java
+++ b/src/main/java/umc/unimade/domain/accounts/controller/BuyerController.java
@@ -6,13 +6,14 @@ import lombok.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import umc.unimade.domain.accounts.dto.BuyerOrderHistoryResponse;
+import umc.unimade.domain.orders.dto.BuyerOrderHistoryResponse;
 import umc.unimade.domain.accounts.dto.BuyerPageResponse;
 import umc.unimade.domain.accounts.entity.Buyer;
 import umc.unimade.domain.accounts.service.BuyerCommandService;
 import umc.unimade.domain.accounts.service.BuyerQueryService;
 import umc.unimade.domain.favorite.dto.FavoriteProductsListResponse;
 import umc.unimade.domain.favorite.dto.FavoriteSellersListResponse;
+import umc.unimade.domain.orders.dto.OrderStatusDetailResponse;
 import umc.unimade.global.common.ApiResponse;
 import umc.unimade.global.common.ErrorCode;
 import umc.unimade.domain.accounts.exception.UserExceptionHandler;
@@ -65,6 +66,19 @@ public class BuyerController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.onFailure(HttpStatus.BAD_REQUEST.name(), e.getMessage()));
         } catch (UserExceptionHandler e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.onFailure(ErrorCode.BUYER_NOT_FOUND.getCode(), ErrorCode.BUYER_NOT_FOUND.getMessage()));
+        }
+    }
+
+    @Tag(name = "Buyer", description = "구매자 관련 API")
+    @Operation(summary = "구매 상세 내역 조회")
+    @GetMapping("/history/{orderId}")
+    public ResponseEntity<ApiResponse<OrderStatusDetailResponse>> getOrderStatusDetail(@PathVariable Long orderId){
+        try {
+            return ResponseEntity.ok(ApiResponse.onSuccess(buyerQueryService.getOrderStatusDetail(orderId)));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.onFailure(HttpStatus.BAD_REQUEST.name(), e.getMessage()));
+        } catch (UserExceptionHandler e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.onFailure(ErrorCode.ORDER_NOT_FOUND.getCode(), ErrorCode.ORDER_NOT_FOUND.getMessage()));
         }
     }
 

--- a/src/main/java/umc/unimade/domain/notification/service/NotificationService.java
+++ b/src/main/java/umc/unimade/domain/notification/service/NotificationService.java
@@ -45,6 +45,8 @@ public class NotificationService {
 
     /*구매자 알림*/
 
+    // TO DO : 프론트와 상의해서 알림을 저장해뒀다가 목록을 반환해야하는지 결정
+    // TO Do : 구매 완료 알림
     // 입금 안내 알림
     @Scheduled(cron = "0 0 10 * * ?")
     public void sendPendingPaymentReminders() {

--- a/src/main/java/umc/unimade/domain/orders/dto/BuyerOrderHistoryResponse.java
+++ b/src/main/java/umc/unimade/domain/orders/dto/BuyerOrderHistoryResponse.java
@@ -1,4 +1,4 @@
-package umc.unimade.domain.accounts.dto;
+package umc.unimade.domain.orders.dto;
 
 import lombok.*;
 import umc.unimade.domain.orders.entity.Orders;

--- a/src/main/java/umc/unimade/domain/orders/dto/OrderStatusDetailResponse.java
+++ b/src/main/java/umc/unimade/domain/orders/dto/OrderStatusDetailResponse.java
@@ -57,6 +57,7 @@ public class OrderStatusDetailResponse {
                 .build();
     }
 
+    // TO DO : deliveryDate 칼럼 추가 시 수정
     public static OrderStatusDetailResponse fromPaidOnlineOrder(Orders order) {
         return commonResponse(order)
                 .deliverDate(order.getProduct().getPickupDate())

--- a/src/main/java/umc/unimade/domain/orders/dto/OrderStatusDetailResponse.java
+++ b/src/main/java/umc/unimade/domain/orders/dto/OrderStatusDetailResponse.java
@@ -1,0 +1,79 @@
+package umc.unimade.domain.orders.dto;
+
+import lombok.*;
+import umc.unimade.domain.orders.entity.OrderItem;
+import umc.unimade.domain.orders.entity.Orders;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderStatusDetailResponse {
+    private String productName;
+    private List<OrderOptionResponse> orderOptions;
+    private Long totalPrice;
+    private String buyerName;
+    private String bankName;
+    private String accountNumber;
+    private String accountName;
+    private LocalDate pickupDate;
+    private String pickupAddress;
+    private LocalDate deliverDate;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class OrderOptionResponse {
+        private List<String> optionValues;
+        private int count;
+
+        public static OrderOptionResponse fromOrderItem(OrderItem orderItem) {
+            List<String> optionValueStrings = orderItem.getOrderOptions().stream()
+                    .map(orderOption -> orderOption.getOptionValue().getValue())
+                    .collect(Collectors.toList());
+            return OrderOptionResponse.builder()
+                    .optionValues(optionValueStrings)
+                    .count(orderItem.getCount())
+                    .build();
+        }
+    }
+
+    public static OrderStatusDetailResponse fromPendingOrder(Orders order) {
+        return commonResponse(order)
+                .bankName(order.getProduct().getBankName())
+                .accountNumber(order.getProduct().getAccountNumber())
+                .accountName(order.getProduct().getAccountName())
+                .build();
+    }
+
+    public static OrderStatusDetailResponse fromPaidOfflineOrder(Orders order) {
+        return commonResponse(order)
+                .pickupDate(order.getPurchaseForm().getPickupDate())
+                .pickupAddress(order.getProduct().getPickupLocation())
+                .build();
+    }
+
+    public static OrderStatusDetailResponse fromPaidOnlineOrder(Orders order) {
+        return commonResponse(order)
+                .deliverDate(order.getProduct().getPickupDate())
+                .build();
+    }
+
+    private static List<OrderOptionResponse> getOrderOptionResponses(Orders order) {
+        return order.getOrderItems().stream()
+                .map(OrderOptionResponse::fromOrderItem)
+                .collect(Collectors.toList());
+    }
+
+    private static OrderStatusDetailResponse.OrderStatusDetailResponseBuilder commonResponse(Orders order) {
+        return OrderStatusDetailResponse.builder()
+                .productName(order.getProduct().getName())
+                .orderOptions(getOrderOptionResponses(order))
+                .totalPrice(order.getTotalPrice())
+                .buyerName(order.getBuyer().getName());
+    }
+}

--- a/src/main/java/umc/unimade/domain/orders/entity/OrderItem.java
+++ b/src/main/java/umc/unimade/domain/orders/entity/OrderItem.java
@@ -5,6 +5,9 @@ import lombok.*;
 import umc.unimade.domain.products.entity.Products;
 import umc.unimade.global.common.BaseEntity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -27,5 +30,8 @@ public class OrderItem extends BaseEntity {
 
     @Column(name = "count", nullable = false)
     private int count;
+
+    @OneToMany(mappedBy = "orderItem", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<OrderOption> orderOptions = new ArrayList<>();
 }
 

--- a/src/main/java/umc/unimade/domain/orders/entity/Orders.java
+++ b/src/main/java/umc/unimade/domain/orders/entity/Orders.java
@@ -6,6 +6,9 @@ import umc.unimade.domain.accounts.entity.Buyer;
 import umc.unimade.domain.products.entity.Products;
 import umc.unimade.global.common.BaseEntity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Builder
 @Getter
@@ -42,6 +45,9 @@ public class Orders extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Products product;
+
+    @OneToMany(mappedBy = "order", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<OrderItem> orderItems = new ArrayList<>();
 
     public void setTotalPrice(Long totalPrice) {
         this.totalPrice = totalPrice;

--- a/src/main/java/umc/unimade/domain/orders/service/OrderCommandService.java
+++ b/src/main/java/umc/unimade/domain/orders/service/OrderCommandService.java
@@ -18,6 +18,8 @@ import umc.unimade.domain.orders.exception.OrderExceptionHandler;
 import umc.unimade.domain.orders.repository.*;
 import umc.unimade.domain.products.entity.OptionValue;
 import umc.unimade.domain.products.entity.PickupOption;
+import umc.unimade.domain.products.entity.ProductStatus;
+import umc.unimade.domain.products.exception.ProductExceptionHandler;
 import umc.unimade.domain.products.repository.ProductRepository;
 import umc.unimade.domain.products.entity.Products;
 import umc.unimade.global.common.ErrorCode;
@@ -46,6 +48,10 @@ public class OrderCommandService {
         validateOrderRequest(orderRequest);
 
         Products product = findProductById(productId);
+
+        if (product.getStatus() != ProductStatus.SELLING) {
+            throw new ProductExceptionHandler(ErrorCode.PRODUCT_STATUS_IS_NOT_SELLING);
+        }
 
         // PurchaseForm 엔티티 생성 및 저장
         PurchaseForm purchaseForm = orderRequest.getPurchaseForm().toEntity();

--- a/src/main/java/umc/unimade/domain/products/dto/ProductDetailResponse.java
+++ b/src/main/java/umc/unimade/domain/products/dto/ProductDetailResponse.java
@@ -1,6 +1,10 @@
 package umc.unimade.domain.products.dto;
 
 import lombok.*;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import umc.unimade.domain.products.entity.ProductDetailImage;
 import umc.unimade.domain.products.entity.Products;
 
 @Getter
@@ -9,10 +13,14 @@ import umc.unimade.domain.products.entity.Products;
 @Builder
 public class ProductDetailResponse {
     private String detail;
+    private List<String> detailImages;
 
     public static ProductDetailResponse from(Products product){
         return ProductDetailResponse.builder()
                 .detail(product.getContent())
+                .detailImages(product.getProductDetailImages().stream()
+                        .map(ProductDetailImage::getImageUrl)
+                        .collect(Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/umc/unimade/domain/products/dto/ProductResponse.java
+++ b/src/main/java/umc/unimade/domain/products/dto/ProductResponse.java
@@ -15,9 +15,6 @@ import umc.unimade.domain.review.dto.ReviewListResponse;
 import java.time.LocalDate;
 import java.util.stream.Collectors;
 
-
-
-
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
@@ -37,7 +34,7 @@ public class ProductResponse {
     private Integer favoriteCount;
     private List<OptionResponse> options;
     private PickupOption pickupOption;
-    private String detail;
+    private ProductDetailResponse detail;
     private ReviewListResponse reviews;
     private QnAListResponse questions;
 
@@ -52,7 +49,9 @@ public class ProductResponse {
                 .categoryName(product.getCategory().getName())
                 .deadline(product.getDeadline())
                 .price(product.getPrice())
-                .productImages(product.getProductImages().stream().map(ProductsImage::getImageUrl).collect(Collectors.toList()))
+                .productImages(product.getProductImages().stream()
+                        .map(ProductsImage::getImageUrl)
+                        .collect(Collectors.toList()))
                 .favoriteCount(product.getFavoriteProducts().size())
                 .options(product.getOptionCategories().stream()
                         .map(OptionResponse::from)
@@ -61,9 +60,9 @@ public class ProductResponse {
                 .build();
     }
 
-    public static ProductResponse toDetail(Products product) {
+    public static ProductResponse toDetail(Products product,ProductDetailResponse detail) {
         ProductResponse response = baseResponse(product);
-        response.setDetail(product.getContent());
+        response.setDetail(detail);
         return response;
     }
 
@@ -80,7 +79,7 @@ public class ProductResponse {
     }
 
 
-    public void setDetail(String detail) {
+    public void setDetail(ProductDetailResponse detail) {
         this.detail = detail;
     }
 

--- a/src/main/java/umc/unimade/domain/products/repository/ProductsRepositoryCustomImpl.java
+++ b/src/main/java/umc/unimade/domain/products/repository/ProductsRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package umc.unimade.domain.products.repository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import umc.unimade.domain.products.entity.ProductStatus;
 import umc.unimade.domain.products.entity.Products;
 import umc.unimade.domain.products.entity.QProducts;
 import umc.unimade.domain.favorite.entity.QFavoriteProduct;
@@ -26,7 +27,8 @@ public class ProductsRepositoryCustomImpl implements ProductsRepositoryCustom {
                         categoryEq(category),
                         keywordContains(keyword),
                         priceBetween(minPrice, maxPrice),
-                        cursorLessThan(cursor)
+                        cursorLessThan(cursor),
+                        statusEq(ProductStatus.SELLING)
                 )
                 .groupBy(products.id)
                 .orderBy(getSortOrder(sort, products, favoriteProduct))
@@ -58,6 +60,10 @@ public class ProductsRepositoryCustomImpl implements ProductsRepositoryCustom {
 
     private BooleanExpression cursorLessThan(Long cursor) {
         return cursor != null ? QProducts.products.id.lt(cursor) : null;
+    }
+
+    private BooleanExpression statusEq(ProductStatus status) {
+        return QProducts.products.status.eq(status);
     }
 
     private OrderSpecifier<?> getSortOrder(String sort, QProducts products, QFavoriteProduct favoriteProduct) {

--- a/src/main/java/umc/unimade/domain/products/service/strategy/DetailStrategy.java
+++ b/src/main/java/umc/unimade/domain/products/service/strategy/DetailStrategy.java
@@ -1,6 +1,7 @@
 package umc.unimade.domain.products.service.strategy;
 
 import org.springframework.stereotype.Component;
+import umc.unimade.domain.products.dto.ProductDetailResponse;
 import umc.unimade.domain.products.entity.Products;
 import umc.unimade.domain.products.dto.ProductResponse;
 
@@ -8,6 +9,7 @@ import umc.unimade.domain.products.dto.ProductResponse;
 public class DetailStrategy implements ProductStrategy{
     @Override
     public ProductResponse loadProduct(Products product, Long cursor, int pageSize) {
-        return ProductResponse.toDetail(product);
+        ProductDetailResponse productDetailResponse = ProductDetailResponse.from(product);
+        return ProductResponse.toDetail(product, productDetailResponse);
     }
 }

--- a/src/main/java/umc/unimade/global/common/ErrorCode.java
+++ b/src/main/java/umc/unimade/global/common/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode implements BaseErrorCode {
     ADDRESS_REQUIRED(HttpStatus.BAD_REQUEST,"ORDER4002","주소는 필수 항목입니다."),
     OPTION_REQUIRED(HttpStatus.BAD_REQUEST,"ORDER4002","옵션을 선택해주세요."),
     COUNT_REQUIRED(HttpStatus.BAD_REQUEST,"ORDER4002","수량은 1개 이상 선택해주세요."),
+    INVALID_ORDER_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "ORDER5000", "서버 에러"),
 
 
     // 판매자 관련 에러


### PR DESCRIPTION
## 📚 개요
+ #97 

## ✏️ 작업 내용
+ 온라인일 때 배송 예정 일자 추가
+ 오프라인일 때 수령 일자 / 수령 장소 추가
+ 상품 상세 정보에 detailImages 추가
+ 상품 주문 시 SELLING 인지 검증
+ 상품 판매 목록에 SELLING인것만 표시 

## 💡 TO DO 
+ 온라인 수령 deliveryDate 칼럼 추가 시 수정 
+ 구매 완료 알림 
