### PR TITLE
✨ [FEATURE] 온라인 수령 시 배송예정일자 추가 #140

### DIFF
--- a/src/main/java/umc/unimade/domain/orders/dto/OrderStatusDetailResponse.java
+++ b/src/main/java/umc/unimade/domain/orders/dto/OrderStatusDetailResponse.java
@@ -21,7 +21,7 @@ public class OrderStatusDetailResponse {
     private String accountName;
     private LocalDate pickupDate;
     private String pickupAddress;
-    private LocalDate deliverDate;
+    private LocalDate deliveryDate;
 
     @Getter
     @NoArgsConstructor
@@ -60,7 +60,7 @@ public class OrderStatusDetailResponse {
     // TO DO : deliveryDate 칼럼 추가 시 수정
     public static OrderStatusDetailResponse fromPaidOnlineOrder(Orders order) {
         return commonResponse(order)
-                .deliverDate(order.getProduct().getPickupDate())
+                .deliveryDate(order.getCreatedAt().toLocalDate().plusDays(5))
                 .build();
     }
 


### PR DESCRIPTION
## 📚 개요
+ #140 

## ✏️ 작업 내용
+  온라인 수령 시 배송예정일자는 주문일 + 5일
+ 구매 내역에서 확인 가능

## 💡 주의 사항
+ 논의 사항을 작성해 주세요.
+ 중점적으로 리뷰받고 싶은 내용을 작성해 주세요.
